### PR TITLE
Fix crash when loading the plugin

### DIFF
--- a/lib/junit/plugin.rb
+++ b/lib/junit/plugin.rb
@@ -108,6 +108,7 @@ module Danger
     #
     # @return   [void]
     def report
+      return if failures.nil? # because danger calls `report` before loading a file
       warn("Skipped #{skipped.count} tests.") if show_skipped_tests && skipped.count > 0
 
       unless failures.empty? && errors.empty?


### PR DESCRIPTION
It seems like danger calls the plugin's `report` method before I get a chance to

```
=> ["/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/pry-0.10.4/lib/pry/pry_instance.rb:355:in `eval'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/pry-0.10.4/lib/pry/pry_instance.rb:355:in `evaluate_ruby'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/pry-0.10.4/lib/pry/pry_instance.rb:323:in `handle_line'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/pry-0.10.4/lib/pry/pry_instance.rb:243:in `block (2 levels) in eval'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/pry-0.10.4/lib/pry/pry_instance.rb:242:in `catch'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/pry-0.10.4/lib/pry/pry_instance.rb:242:in `block in eval'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/pry-0.10.4/lib/pry/pry_instance.rb:241:in `catch'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/pry-0.10.4/lib/pry/pry_instance.rb:241:in `eval'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/pry-0.10.4/lib/pry/repl.rb:77:in `block in repl'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/pry-0.10.4/lib/pry/repl.rb:67:in `loop'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/pry-0.10.4/lib/pry/repl.rb:67:in `repl'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/pry-0.10.4/lib/pry/repl.rb:38:in `block in start'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/pry-0.10.4/lib/pry/input_lock.rb:61:in `call'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/pry-0.10.4/lib/pry/input_lock.rb:61:in `__with_ownership'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/pry-0.10.4/lib/pry/input_lock.rb:79:in `with_ownership'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/pry-0.10.4/lib/pry/repl.rb:38:in `start'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/pry-0.10.4/lib/pry/repl.rb:15:in `start'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/pry-0.10.4/lib/pry/pry_class.rb:169:in `start'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/pry-0.10.4/lib/pry/core_extensions.rb:43:in `pry'",
 "/Users/fkrause/Developer/hacking/danger-junit/lib/junit/plugin.rb:115:in `report'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/bundler/gems/danger-a67bc71710d9/lib/danger/danger_core/dangerfile.rb:129:in `block (2 levels) in method_values_for_plugin_hashes'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/bundler/gems/danger-a67bc71710d9/lib/danger/danger_core/dangerfile.rb:116:in `map'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/bundler/gems/danger-a67bc71710d9/lib/danger/danger_core/dangerfile.rb:116:in `block in method_values_for_plugin_hashes'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/bundler/gems/danger-a67bc71710d9/lib/danger/danger_core/dangerfile.rb:112:in `each'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/bundler/gems/danger-a67bc71710d9/lib/danger/danger_core/dangerfile.rb:112:in `flat_map'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/bundler/gems/danger-a67bc71710d9/lib/danger/danger_core/dangerfile.rb:112:in `method_values_for_plugin_hashes'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/bundler/gems/danger-a67bc71710d9/lib/danger/danger_core/dangerfile.rb:145:in `print_known_info'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/bundler/gems/danger-a67bc71710d9/lib/danger/danger_core/dangerfile.rb:167:in `parse'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/bundler/gems/danger-a67bc71710d9/lib/danger/commands/local.rb:109:in `run'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/claide-1.0.0/lib/claide/command.rb:334:in `run'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/bundler/gems/danger-a67bc71710d9/bin/danger:5:in `<top (required)>'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/bin/danger:22:in `load'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/bin/danger:22:in `<top (required)>'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/bundler-1.12.4/lib/bundler/cli/exec.rb:63:in `load'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/bundler-1.12.4/lib/bundler/cli/exec.rb:63:in `kernel_load'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/bundler-1.12.4/lib/bundler/cli/exec.rb:24:in `run'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/bundler-1.12.4/lib/bundler/cli.rb:304:in `exec'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/bundler-1.12.4/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/bundler-1.12.4/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/bundler-1.12.4/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/bundler-1.12.4/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/bundler-1.12.4/lib/bundler/cli.rb:11:in `start'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/bundler-1.12.4/exe/bundle:27:in `block in <top (required)>'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/bundler-1.12.4/lib/bundler/friendly_errors.rb:98:in `with_friendly_errors'",
 "/Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/bundler-1.12.4/exe/bundle:19:in `<top (required)>'",
 "/Users/fkrause/.rbenv/versions/2.2.1/bin/bundle:23:in `load'",
 "/Users/fkrause/.rbenv/versions/2.2.1/bin/bundle:23:in `<main>'"]
```
