### PR TITLE
Add comma to method description

### DIFF
--- a/lib/junit/plugin.rb
+++ b/lib/junit/plugin.rb
@@ -80,7 +80,7 @@ module Danger
     # @return   [Array<Symbol>]
     attr_accessor :headers
 
-    # Parses an XML file, which fills all the attributes
+    # Parses an XML file, which fills all the attributes,
     # will `raise` for errors
     # @return   [void]
     def parse(file)


### PR DESCRIPTION
Sentence is confusing in docs.

<img width="618" alt="bildschirmfoto 2016-08-08 um 19 40 31" src="https://cloud.githubusercontent.com/assets/68024/17490070/6123a170-5da1-11e6-805a-8efbe6a3702f.png">
