### PR TITLE
Correct @see annotations

### DIFF
--- a/lib/junit/plugin.rb
+++ b/lib/junit/plugin.rb
@@ -39,7 +39,9 @@ module Danger
   #          message "#{slowest_test[:time]} took #{slowest_test[:time]} seconds"
   #
   #
-  # @see  orta/danger-junit, danger/danger, artsy/eigen
+  # @see  orta/danger-junit
+  # @see  danger/danger
+  # @see  artsy/eigen
   # @tags testing, reporting, junit, rspec, jasmine, jest, xcpretty
   #
   class DangerJunit < Plugin


### PR DESCRIPTION
It seems multiple @see annotations should not be comma-separated but listed with multiple @see-s. http://www.rubydoc.info/gems/yard/file/docs/Tags.md#see

Currently this results in a broken (and missing the others) link. 

<img width="528" alt="bildschirmfoto 2016-08-08 um 20 13 53" src="https://cloud.githubusercontent.com/assets/68024/17490819/11300614-5da5-11e6-8a43-71375fa06b8b.png">

Not an expert on yard doc style at all. I went debugging the danger plugin parser and eventually settled on simply splitting the @sees lol.
