### PR TITLE
Fix for empty testsuites

### DIFF
--- a/lib/junit/plugin.rb
+++ b/lib/junit/plugin.rb
@@ -92,10 +92,10 @@ module Danger
       @doc = Ox.parse(xml_string)
 
       suite_root = @doc.nodes.first.value == 'testsuites' ? @doc.nodes.first : @doc
-      @tests = suite_root.nodes.map(&:nodes).flatten.select { |node| node.value == 'testcase' }
+      @tests = suite_root.nodes.map(&:nodes).flatten.select { |node| node.kind_of?(Ox::Element) && node.value == 'testcase' }
 
       failed_suites = suite_root.nodes.select { |suite| suite[:failures].to_i > 0 || suite[:errors].to_i > 0 }
-      failed_tests = failed_suites.map(&:nodes).flatten.select { |node| node.value == 'testcase' }
+      failed_tests = failed_suites.map(&:nodes).flatten.select { |node| node.kind_of?(Ox::Element) && node.value == 'testcase' }
 
       @failures = failed_tests.select do |test| 
         test.nodes.count > 0

--- a/spec/fixtures/fastlane_trainer.xml
+++ b/spec/fixtures/fastlane_trainer.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites tests="2" failures="1">
+    <testsuite name="EmptyTests" tests="0" failures="0">
+    </testsuite>
     <testsuite name="ThemojiUITests" tests="2" failures="1">
         <testcase classname="ThemojiUITests" name="testExample()">
         </testcase>


### PR DESCRIPTION
When using [trainer](https://github.com/KrauseFx/trainer), we came across an empty `<testsuite>` that would crash the danger-junit plugin as ox parsed the testsuite with one `\n` string child. Checking for `kind_of?(Ox::Element)` two more times in the parsing method fixes this. I also added an empty testsuite in the trainer xml fixture to test this special case.