### PR TITLE
Implementing junit.parse_files to enable reporting from multiple files

### DIFF
--- a/lib/junit/plugin.rb
+++ b/lib/junit/plugin.rb
@@ -14,6 +14,16 @@ module Danger
   #          junit.parse "/path/to/output.xml"
   #          junit.report
   #
+  # @example Parse multiple XML files by passing multiple file names
+  #
+  #          junit.parse_files "/path/to/integration-tests.xml", "/path/to/unit-tests.xml"
+  #          junit.report
+  #
+  # @example Parse multiple XML files by passing an array
+  #          result_files = %w(/path/to/integration-tests.xml /path/to/unit-tests.xml)
+  #          junit.parse_files result_files
+  #          junit.report
+  #
   # @example Let the plugin parse the XML file, and report yourself
   #
   #          junit.parse "/path/to/output.xml"
@@ -97,7 +107,7 @@ module Danger
       @tests = []
       failed_tests = []
 
-      Array(files).each do |file|
+      Array(files).flatten.each do |file|
         raise "No JUnit file was found at #{file}" unless File.exist? file
 
         xml_string = File.read(file)

--- a/lib/junit/plugin.rb
+++ b/lib/junit/plugin.rb
@@ -76,7 +76,8 @@ module Danger
     attr_accessor :show_skipped_tests
 
     # An array of symbols that become the columns of your tests,
-    # if `nil`, the default, it will be all of the attributes.
+    # if `nil`, the default, it will be all of the attributes for a single parse
+    # or all of the common attributes between multiple files
     #
     # @return   [Array<Symbol>]
     attr_accessor :headers
@@ -147,14 +148,15 @@ module Danger
 
         tests = (failures + errors)
 
+        common_attributes = tests.map{|test| test.attributes.keys }.inject(&:&)
+
         # check the provided headers are available
         unless headers.nil?
-          attributtesKey = tests.first.attributes.keys
-          not_available_headers = headers.select { |header| not attributtesKey.include?(header) }
+          not_available_headers = headers.select { |header| not common_attributes.include?(header) }
           raise "Some of headers provided aren't available in the JUnit report (#{not_available_headers})" unless not_available_headers.empty?
         end
 
-        keys = headers || tests.first.attributes.keys
+        keys = headers || common_attributes
         attributes = keys.map(&:to_s).map(&:capitalize)
 
         # Create the headers

--- a/spec/junit_spec.rb
+++ b/spec/junit_spec.rb
@@ -49,15 +49,6 @@ module Danger
         expect(@junit.skipped.count).to eq 7
       end
 
-      it 'gets the right results for multiple files' do
-        @junit.parse_files 'spec/fixtures/rspec_fail.xml', 'spec/fixtures/fastlane_trainer.xml'
-
-        expect(@junit.failures.count).to eq 1 + 1
-        expect(@junit.passes.count).to eq 190 + 1
-        expect(@junit.errors.count).to eq 0 + 0
-        expect(@junit.skipped.count).to eq 7 + 0
-      end
-
       it 'shows a known markdown row' do
         @junit.parse 'spec/fixtures/rspec_fail.xml'
         @junit.report
@@ -95,6 +86,26 @@ module Danger
 
         outputs = @junit.status_report[:markdowns].first
         expect(outputs.to_s).to include('github.com/thing/thingy')
+      end
+
+      describe 'parsing multiple files' do
+        it 'gets the right results for multiple files' do
+          @junit.parse_files 'spec/fixtures/rspec_fail.xml', 'spec/fixtures/fastlane_trainer.xml'
+
+          expect(@junit.failures.count).to eq 1 + 1
+          expect(@junit.passes.count).to eq 190 + 1
+          expect(@junit.errors.count).to eq 0 + 0
+          expect(@junit.skipped.count).to eq 7 + 0
+        end
+
+        it 'defaults to reporting common attributes for multiple files' do
+          @junit.parse_files 'spec/fixtures/rspec_fail.xml', 'spec/fixtures/eigen_fail.xml'
+
+          @junit.report
+
+          outputs = @junit.status_report[:markdowns].first
+          expect(outputs.to_s).to include('Classname | Name')
+        end
       end
     end
   end

--- a/spec/junit_spec.rb
+++ b/spec/junit_spec.rb
@@ -98,6 +98,16 @@ module Danger
           expect(@junit.skipped.count).to eq 7 + 0
         end
 
+        it 'gets the right results for an array of files' do
+          files = %w(spec/fixtures/rspec_fail.xml spec/fixtures/fastlane_trainer.xml)
+          @junit.parse_files files
+
+          expect(@junit.failures.count).to eq 1 + 1
+          expect(@junit.passes.count).to eq 190 + 1
+          expect(@junit.errors.count).to eq 0 + 0
+          expect(@junit.skipped.count).to eq 7 + 0
+        end
+
         it 'defaults to reporting common attributes for multiple files' do
           @junit.parse_files 'spec/fixtures/rspec_fail.xml', 'spec/fixtures/eigen_fail.xml'
 

--- a/spec/junit_spec.rb
+++ b/spec/junit_spec.rb
@@ -49,6 +49,15 @@ module Danger
         expect(@junit.skipped.count).to eq 7
       end
 
+      it 'gets the right results for multiple files' do
+        @junit.parse_files 'spec/fixtures/rspec_fail.xml', 'spec/fixtures/fastlane_trainer.xml'
+
+        expect(@junit.failures.count).to eq 1 + 1
+        expect(@junit.passes.count).to eq 190 + 1
+        expect(@junit.errors.count).to eq 0 + 0
+        expect(@junit.skipped.count).to eq 7 + 0
+      end
+
       it 'shows a known markdown row' do
         @junit.parse 'spec/fixtures/rspec_fail.xml'
         @junit.report


### PR DESCRIPTION
Closes #18 

I considered updating the method signature of `parse` to allow multiple files. But if there are existing Dangerfiles out there that invoked parse multiple times we'd be changing behaviour. That seems like bad behaviour to preserve so I'm happy to refactor and keep the API to just `parse`. But for now I just implemented `parse_files`