### PR TITLE
Add method which load all file matching a given Pattern.

### DIFF
--- a/lib/junit/plugin.rb
+++ b/lib/junit/plugin.rb
@@ -106,6 +106,15 @@ module Danger
       parse_files(file)
     end
 
+    # Load all XML file that match the given pattern
+    # This allow to load all file in a given directory, instead of identifying each file specifically.
+    # will `raise` for errors
+    # @return   [void]
+    def parse_pattern(pattern)
+      files_in_pattern = Dir.glob(pattern)
+      parse_files(files_in_pattern)
+    end
+
     # Parses multiple XML files, which fills all the attributes,
     # will `raise` for errors
     # @return   [void]

--- a/spec/junit_spec.rb
+++ b/spec/junit_spec.rb
@@ -108,6 +108,16 @@ module Danger
           expect(@junit.skipped.count).to eq 7 + 0
         end
 
+        it 'gets the right results for an pattern of files' do
+          files = 'spec/fixtures/*.xml'
+          @junit.parse_pattern files
+
+          expect(@junit.failures.count).to eq 6
+          expect(@junit.passes.count).to eq 1346
+          expect(@junit.errors.count).to eq 0 + 0
+          expect(@junit.skipped.count).to eq 1+ 7 + 0
+        end
+
         it 'defaults to reporting common attributes for multiple files' do
           @junit.parse_files 'spec/fixtures/rspec_fail.xml', 'spec/fixtures/eigen_fail.xml'
 


### PR DESCRIPTION
In Dangerfile, simply have

junit.parse_pattern "spec/reports/*.xml"

to load all xml file in the given directory

orta/danger-junit#30